### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Closes #6

## Summary

Adds the **GitHub Skills** activity to the extracurricular activities list, as announced by the principal and reported missing by a student.

## Changes

- Added `GitHub Skills` entry to the in-memory activities database in `src/app.py`
  - Description highlights the GitHub Certifications program
  - Scheduled for Wednesdays, 3:30 PM – 5:00 PM
  - Max participants: 25
  - Open for registration (empty participants list)